### PR TITLE
Fix Auth States on Error

### DIFF
--- a/src/auth/useDeleteUser.ts
+++ b/src/auth/useDeleteUser.ts
@@ -3,6 +3,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+import { FirebaseError } from "firebase/app";
 import { Auth, deleteUser, signOut } from "firebase/auth";
 import { useEffect, useState } from "react";
 import { useUser } from ".";
@@ -42,9 +43,16 @@ export const useDeleteUser = (
   const dispatch: UseDeleteUserDispatcher = async () => {
     if (user) {
       setState("loading");
-      await deleteUser(user);
-      await signOut(auth);
-      setState("anonymous");
+      try {
+        await deleteUser(user);
+        await signOut(auth);
+        setState("anonymous");
+      } catch (e) {
+        if (e instanceof FirebaseError) {
+          setState("ready");
+          throw e;
+        }
+      }
     }
   };
 

--- a/src/auth/useDeleteUser.ts
+++ b/src/auth/useDeleteUser.ts
@@ -3,7 +3,6 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { FirebaseError } from "firebase/app";
 import { Auth, deleteUser, signOut } from "firebase/auth";
 import { useEffect, useState } from "react";
 import { useUser } from ".";
@@ -48,10 +47,8 @@ export const useDeleteUser = (
         await signOut(auth);
         setState("anonymous");
       } catch (e) {
-        if (e instanceof FirebaseError) {
-          setState("ready");
-          throw e;
-        }
+        setState("ready");
+        throw e;
       }
     }
   };

--- a/src/auth/useSendEmailVerification.ts
+++ b/src/auth/useSendEmailVerification.ts
@@ -33,11 +33,16 @@ export const useSendEmailVerification = (
     actionCodeSetting,
   ) => {
     setState("loading");
-    await sendEmailVerification(
-      user!, // guaranteed user not null on ready
-      actionCodeSetting,
-    );
-    setState("done");
+    try {
+      await sendEmailVerification(
+        user!, // guaranteed user not null on ready
+        actionCodeSetting,
+      );
+      setState("done");
+    } catch (e) {
+      setState("ready");
+      throw e;
+    }
   };
 
   return { state, dispatch: state === "ready" ? dispatch : async () => {} };

--- a/src/auth/useSignIn.ts
+++ b/src/auth/useSignIn.ts
@@ -74,63 +74,107 @@ export const useSignIn = (auth: Auth): UseSignIn => {
     switch (type) {
       case "classic": {
         const { email, password } = params;
-        const credential = await signInWithEmailAndPassword(
-          auth,
-          email,
-          password,
-        );
-        setState("authenticated");
-        return credential;
+        try {
+          const credential = await signInWithEmailAndPassword(
+            auth,
+            email,
+            password,
+          );
+          setState("authenticated");
+          return credential;
+        } catch (e) {
+          setState("ready");
+          throw e;
+        }
       }
       case "link": {
         const { email, actionCodeSetting } = params;
-        await sendSignInLinkToEmail(auth, email, actionCodeSetting);
-        setState("awaiting");
-        return undefined;
+        try {
+          await sendSignInLinkToEmail(auth, email, actionCodeSetting);
+          setState("awaiting");
+          return undefined;
+        } catch (e) {
+          setState("ready");
+          throw e;
+        }
       }
       case "google": {
         const { provider } = params;
-        const credential = await signInWithPopup(auth, provider);
-        setState("authenticated");
-        setState("authenticated");
-        return credential;
+        try {
+          const credential = await signInWithPopup(auth, provider);
+          setState("authenticated");
+          return credential;
+        } catch (e) {
+          setState("ready");
+          throw e;
+        }
       }
       case "facebook": {
         const { provider } = params;
-        const credential = await signInWithPopup(auth, provider);
-        setState("authenticated");
-        setState("authenticated");
-        return credential;
+        try {
+          const credential = await signInWithPopup(auth, provider);
+          setState("authenticated");
+          return credential;
+        } catch (e) {
+          setState("ready");
+          throw e;
+        }
       }
       case "apple": {
         const { provider } = params;
-        const credential = await signInWithPopup(auth, provider);
-        setState("authenticated");
-        return credential;
+        try {
+          const credential = await signInWithPopup(auth, provider);
+          setState("authenticated");
+          return credential;
+        } catch (e) {
+          const credential = await signInWithPopup(auth, provider);
+          setState("authenticated");
+          return credential;
+        }
       }
       case "twitter": {
         const { provider } = params;
-        const credential = await signInWithPopup(auth, provider);
-        setState("authenticated");
-        return credential;
+        try {
+          const credential = await signInWithPopup(auth, provider);
+          setState("authenticated");
+          return credential;
+        } catch (e) {
+          setState("ready");
+          throw e;
+        }
       }
       case "github": {
         const { provider } = params;
-        const credential = await signInWithPopup(auth, provider);
-        setState("authenticated");
-        return credential;
+        try {
+          const credential = await signInWithPopup(auth, provider);
+          setState("authenticated");
+          return credential;
+        } catch (e) {
+          setState("ready");
+          throw e;
+        }
       }
       case "microsoft": {
         const { provider } = params;
-        const credential = await signInWithPopup(auth, provider);
-        setState("authenticated");
-        return credential;
+        try {
+          const credential = await signInWithPopup(auth, provider);
+          setState("authenticated");
+          return credential;
+        } catch (e) {
+          setState("ready");
+          throw e;
+        }
       }
       case "yahoo": {
         const { provider } = params;
-        const credential = await signInWithPopup(auth, provider);
-        setState("authenticated");
-        return credential;
+        try {
+          const credential = await signInWithPopup(auth, provider);
+          setState("authenticated");
+          return credential;
+        } catch (e) {
+          setState("ready");
+          throw e;
+        }
       }
     }
   };

--- a/src/auth/useSignOut.ts
+++ b/src/auth/useSignOut.ts
@@ -47,8 +47,13 @@ export const useSignOut = (
 
   const dispatch: UseSignOutDispatcher = async () => {
     setState("loading");
-    await auth.signOut();
-    setState("anonymous");
+    try {
+      await auth.signOut();
+      setState("anonymous");
+    } catch (e) {
+      setState("ready");
+      throw e;
+    }
   };
 
   return { state, dispatch: state === "ready" ? dispatch : async () => {} };

--- a/src/auth/useSignUp.ts
+++ b/src/auth/useSignUp.ts
@@ -31,13 +31,18 @@ export const useSignUp = (auth: Auth): UseSignUp => {
 
   const dispatch: UseSignUpDispatcher = async (email, password) => {
     setState("loading");
-    const credential = await createUserWithEmailAndPassword(
-      auth,
-      email,
-      password,
-    );
-    setState("authenticated");
-    return credential;
+    try {
+      const credential = await createUserWithEmailAndPassword(
+        auth,
+        email,
+        password,
+      );
+      setState("authenticated");
+      return credential;
+    } catch (e) {
+      setState("ready");
+      throw e;
+    }
   };
 
   return {


### PR DESCRIPTION
Catch and rethrow errors while setting the state to `"ready"` in auth-related hooks.